### PR TITLE
TAC-LS patch for MKS-LITE

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
@@ -121,7 +121,8 @@
 		@maxAmount *=6.1728395
 		isTweakable = True
 	}	
-	@RESOURCE[Mulch]
+	!RESOURCE[Mulch] {}
+	RESOURCE
 	{
 		name = CarbonDioxide
 		amount = 0

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
@@ -70,17 +70,17 @@
 	{
 		name = Food
 		amount = 0
-		@maxAmount = 1.097 // 2 days worth from TAC-LS
-		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395 // from 200 Supplies ~= 12 days worth
+		// MKS-Lite provides 200 supplies, enough for 1 kerbal for ~12 days
+		// which is 4x as much as the standard TAC-LS allowance
+		@maxAmount = 1.097 // enough for 1 kerbal for 3 days
+		@maxAmount *=4 // enough for 1 kerbal for 12 days
 		isTweakable = True
 	}
     	RESOURCE
 	{
 		name = Oxygen
 		maxAmount = 111.038
-		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395
+		@maxAmount *=4
 		amount = #$maxAmount$
 		isTweakable = True
 	}
@@ -89,8 +89,7 @@
 		name = Water
 		amount = 0
 		maxAmount = 0.725
-		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395
+		@maxAmount *=4
 		isTweakable = True
 	}	
 }
@@ -112,9 +111,9 @@
 	{
 		name = Food
 		amount = 0
-		@maxAmount = 1.097 // from TAC-LS 
-		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395
+		// MKS-LITE provides 200 supplies, enough for 1 kerbal for ~12 days, or 4 kerbals for ~3 days
+		@maxAmount = 1.097 // enough for 1 kerbal for 3 days
+		@maxAmount *= #$/CrewCapacityDeployed$ // enough for 4 kerbals for 3 days
 		isTweakable = True
 	}
 	RESOURCE
@@ -122,7 +121,6 @@
 		name = Oxygen
 		maxAmount = 111.038
 		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395
 		amount = #$maxAmount$
 		isTweakable = True
 	}	
@@ -132,7 +130,6 @@
 		amount = 0
 		maxAmount = 0.725
 		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395
 		isTweakable = True
 	}	
 	!RESOURCE[Mulch] {}
@@ -142,7 +139,6 @@
 		amount = 0
 		@maxAmount = 95.913
 		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395
 		isTweakable = True
 	}
 	RESOURCE
@@ -151,7 +147,6 @@
 		amount = 0
 		maxAmount = 0.924
 		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395
 		isTweakable = True
 	}
 	RESOURCE
@@ -160,7 +155,6 @@
 		amount = 0
 		maxAmount = 0.1
 		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6.1728395
 		isTweakable = True
 	}
 }
@@ -177,6 +171,7 @@
 	{
 		@resourceNames = Dirt,Ore;MaterialKits;Food,Water,Oxygen;RareMetals,ExoticMinerals;Waste,WasteWater,CarbonDioxide
 		// 35 supplies = two day's worth of storage
+		// for simplicities sake we will give 3 days worth, since that's the TAC-LS default
 		@resourceAmounts = 35,7;70;1.097,0.725,111.038;35,35;0.1,0.924,95.913
 		@initialResourceAmounts = 0,0;0,0;0,0,0;0,0;0,0,0;
 		@tankCost = 3500;3500;3500;3500;3500

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
@@ -65,7 +65,7 @@
 		amount = 0
 		maxAmount = 1.097 // 2 days worth from TAC-LS
 		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6 // from 200 Supplies ~= 12 days worth
+		@maxAmount *=6.1728395 // from 200 Supplies ~= 12 days worth
 		isTweakable = True
 	}
     	RESOURCE
@@ -74,7 +74,7 @@
 		amount = 0
 		maxAmount = 111.038
 		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6
+		@maxAmount *=6.1728395
 		isTweakable = True
 	}
     	RESOURCE
@@ -83,7 +83,7 @@
 		amount = 0
 		maxAmount = 0.725
 		@maxAmount *= #$/CrewCapacityDeployed$
-		@maxAmount *=6
+		@maxAmount *=6.1728395
 		isTweakable = True
 	}	
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
@@ -63,8 +63,9 @@
 	{
 		name = Food
 		amount = 0
-		maxAmount = 1.097 // from TAC-LS
+		maxAmount = 1.097 // 2 days worth from TAC-LS
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6 // from 200 Supplies ~= 12 days worth
 		isTweakable = True
 	}
     	RESOURCE
@@ -73,6 +74,7 @@
 		amount = 0
 		maxAmount = 111.038
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6
 		isTweakable = True
 	}
     	RESOURCE
@@ -81,6 +83,7 @@
 		amount = 0
 		maxAmount = 0.725
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6
 		isTweakable = True
 	}	
 }
@@ -97,6 +100,7 @@
 		amount = 0
 		maxAmount = 1.097 // from TAC-LS 
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6.1728395
 		isTweakable = True
 	}	
 	RESOURCE
@@ -105,6 +109,7 @@
 		amount = 0
 		maxAmount = 111.038
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6.1728395
 		isTweakable = True
 	}	
 	RESOURCE
@@ -113,6 +118,7 @@
 		amount = 0
 		maxAmount = 0.725
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6.1728395
 		isTweakable = True
 	}	
 	@RESOURCE[Mulch]
@@ -121,6 +127,7 @@
 		amount = 0
 		maxAmount = 95.913
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6.1728395
 		isTweakable = True
 	}
 	RESOURCE
@@ -129,6 +136,7 @@
 		amount = 0
 		maxAmount = 0.924
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6.1728395
 		isTweakable = True
 	}
 	RESOURCE
@@ -137,6 +145,7 @@
 		amount = 0
 		maxAmount = 0.1
 		@maxAmount *= #$/CrewCapacityDeployed$
+		@maxAmount *=6.1728395
 		isTweakable = True
 	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
@@ -58,23 +58,20 @@
 	
 	%CrewCapacityDeployed = 1	// assumption, might be more
     
-	!RESOURCE[Supplies] {}
-	RESOURCE
+	@RESOURCE[Supplies]
 	{
-		name = Food
-		amount = 0
-		maxAmount = 1.097 // 2 days worth from TAC-LS
+		@name = Food
+		@maxAmount = 1.097 // 2 days worth from TAC-LS
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395 // from 200 Supplies ~= 12 days worth
-		isTweakable = True
 	}
     	RESOURCE
 	{
 		name = Oxygen
-		amount = 0
 		maxAmount = 111.038
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395
+		amount = #$maxAmount$
 		isTweakable = True
 	}
     	RESOURCE
@@ -93,23 +90,20 @@
 {
 	%CrewCapacityDeployed = 4
 
-	!RESOURCE[Supplies] {}
-	RESOURCE
+	@RESOURCE[Supplies]
 	{
-		name = Food
-		amount = 0
-		maxAmount = 1.097 // from TAC-LS 
+		@name = Food
+		@maxAmount = 1.097 // from TAC-LS 
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395
-		isTweakable = True
 	}	
 	RESOURCE
 	{
 		name = Oxygen
-		amount = 0
 		maxAmount = 111.038
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395
+		amount = #$maxAmount$
 		isTweakable = True
 	}	
 	RESOURCE
@@ -121,15 +115,12 @@
 		@maxAmount *=6.1728395
 		isTweakable = True
 	}	
-	!RESOURCE[Mulch] {}
-	RESOURCE
+	@RESOURCE[Mulch]
 	{
-		name = CarbonDioxide
-		amount = 0
-		maxAmount = 95.913
+		@name = CarbonDioxide
+		@maxAmount = 95.913
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395
-		isTweakable = True
 	}
 	RESOURCE
 	{
@@ -148,6 +139,25 @@
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395
 		isTweakable = True
+	}
+}
+
+@PART[MKSL_ILM]:NEEDS[TACLifeSupport]
+{
+	@MODULE[FStextureSwitch2]
+	{
+		@textureNames = UmbraSpaceIndustries/MKS-LITE/Assets/SW_01;UmbraSpaceIndustries/MKS-LITE/Assets/SW_02;UmbraSpaceIndustries/MKS-LITE/Assets/SW_03;UmbraSpaceIndustries/MKS-LITE/Assets/SW_04;UmbraSpaceIndustries/MKS-LITE/Assets/SW_05;
+		@textureDisplayNames = Raw Materials;Refined Goods;Supplies;Commodities;Waste
+		@fuelTankSetups = 0;1;2;3;4
+	}
+	@MODULE[FSfuelSwitch]
+	{
+		@resourceNames = Dirt,Ore;MaterialKits;Food,Water,Oxygen;RareMetals,ExoticMinerals;Waste,WasteWater,CarbonDioxide
+		// 35 supplies = two day's worth of storage
+		@resourceAmounts = 35,7;70;1.097,0.725,111.038;35,35;0.1,0.924,95.913
+		@initialResourceAmounts = 0,0;0,0;0,0,0;0,0;0,0,0;
+		@tankCost = 3500;3500;3500;3500;3500
+		@tankMass = 0;0;0;0;0;
 	}
 }
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
@@ -57,13 +57,23 @@
 	}
 	
 	%CrewCapacityDeployed = 1	// assumption, might be more
-    
-	@RESOURCE[Supplies]
+
+    	// add TAC life support
+	MODULE
 	{
-		@name = Food
+		name = LifeSupportModule
+	}
+	
+	// add TAC resources
+	!RESOURCE[Supplies] {}
+	RESOURCE
+	{
+		name = Food
+		amount = 0
 		@maxAmount = 1.097 // 2 days worth from TAC-LS
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395 // from 200 Supplies ~= 12 days worth
+		isTweakable = True
 	}
     	RESOURCE
 	{
@@ -90,13 +100,23 @@
 {
 	%CrewCapacityDeployed = 4
 
-	@RESOURCE[Supplies]
+	// add TAC life support
+	MODULE
 	{
-		@name = Food
+		name = LifeSupportModule
+	}
+
+	// add TAC resources
+	!RESOURCE[Supplies] {}
+	RESOURCE
+	{
+		name = Food
+		amount = 0
 		@maxAmount = 1.097 // from TAC-LS 
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395
-	}	
+		isTweakable = True
+	}
 	RESOURCE
 	{
 		name = Oxygen
@@ -115,12 +135,15 @@
 		@maxAmount *=6.1728395
 		isTweakable = True
 	}	
-	@RESOURCE[Mulch]
+	!RESOURCE[Mulch] {}
+	RESOURCE
 	{
-		@name = CarbonDioxide
+		name = CarbonDioxide
+		amount = 0
 		@maxAmount = 95.913
 		@maxAmount *= #$/CrewCapacityDeployed$
 		@maxAmount *=6.1728395
+		isTweakable = True
 	}
 	RESOURCE
 	{

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Kolonization/TAC-LS.cfg
@@ -55,6 +55,90 @@
 			%DumpExcess = True
 		}
 	}
+	
+	%CrewCapacityDeployed = 1	// assumption, might be more
+    
+	!RESOURCE[Supplies] {}
+	RESOURCE
+	{
+		name = Food
+		amount = 0
+		maxAmount = 1.097 // from TAC-LS
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}
+    	RESOURCE
+	{
+		name = Oxygen
+		amount = 0
+		maxAmount = 111.038
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}
+    	RESOURCE
+	{
+		name = Water
+		amount = 0
+		maxAmount = 0.725
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}	
+}
+
+// assumptions: deployed HabModule is intended to have a CrewCapacity of 4
+@PART[MKSL_HabModule]:NEEDS[TACLifeSupport]
+{
+	%CrewCapacityDeployed = 4
+
+	!RESOURCE[Supplies] {}
+	RESOURCE
+	{
+		name = Food
+		amount = 0
+		maxAmount = 1.097 // from TAC-LS 
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}	
+	RESOURCE
+	{
+		name = Oxygen
+		amount = 0
+		maxAmount = 111.038
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}	
+	RESOURCE
+	{
+		name = Water
+		amount = 0
+		maxAmount = 0.725
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}	
+	@RESOURCE[Mulch]
+	{
+		name = CarbonDioxide
+		amount = 0
+		maxAmount = 95.913
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		amount = 0
+		maxAmount = 0.924
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}
+	RESOURCE
+	{
+		name = Waste
+		amount = 0
+		maxAmount = 0.1
+		@maxAmount *= #$/CrewCapacityDeployed$
+		isTweakable = True
+	}
 }
 
 @PART[*_Aeroponics]:NEEDS[TACLifeSupport]

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS-LITE/Parts/MKSL_AgModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS-LITE/Parts/MKSL_AgModule.cfg
@@ -39,6 +39,8 @@ PART
 	crashTolerance = 15
 	breakingForce = 250
 	breakingTorque = 250
+	
+	CrewCapacity = 0 // starts undeployed
 
 	MODULE
 	{
@@ -101,6 +103,9 @@ PART
 	{
 		name = USIAnimation
 		animationName = Deploy
+		inflatable = true
+		InflatedResourceThreshold = 100
+		CrewCapacity = 1 // or whatever the max is supposed to be
 	}
 
 	MODULE


### PR DESCRIPTION
hi, 

here's a patch that:

* fixes the problem whereby the Ag Module can't be entered after deployment, despite needing crew to operate it.
* assumes AgricultureModule is intended to have CrewCapacity of 1 and Hab Module a CrewCapacity of 4
* adds TAC LifeSupportModule to Ag Module and Hab
* replaces USI-LS resources with TAC-LS resources for Ag Module and Hab, in the same proportions (based on 200 supplies = ~12 days for 1 kerbal)
* adds TAC-LS resources and waste products to the ILM Warehouse, removes USI-LS

i note that as provided, the maximum amount of USI-LS storage available in the ILM seems really low: two days of supplies/mulch (35 units) vs ~12 days (200 units) in the hab module by default. maybe it should be bumped up? in any case, i've followed the default and provided 2 days of TAC-LS/waste storage.